### PR TITLE
Add 'dnspython' dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 ### Prerequisites
 - Support For Python 2.7
 - Pandas
+- dnspython
 ```
-      pip install pandas
+      pip install pandas dnspython
 ```
 
 ### Reading Suggestions


### PR DESCRIPTION
Without this dependency, I get the following error message:

```
Traceback (most recent call last):
  File "NSDetect.py", line 3, in <module>
    import dns.resolver
ImportError: No module named dns.resolver
```